### PR TITLE
Upgrade Go version to 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22'
+        go-version: '1.25'
 
     - name: Test
       run: go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.25 AS builder
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/lazydevorg/downtown
 
-go 1.23.0
+go 1.25


### PR DESCRIPTION
Updated Go version across all configuration files:
- go.mod: 1.23.0 -> 1.25
- Dockerfile: golang:1.23 -> golang:1.25
- GitHub workflow: 1.22 -> 1.25

All tests verified to pass with the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)